### PR TITLE
Match version number in code to current release

### DIFF
--- a/sources/commands.cpp
+++ b/sources/commands.cpp
@@ -890,7 +890,7 @@ public:
 class VersionCommand : public CommandBase
 {
 private:
-    const char* version = "0.5.0";
+    const char* version = "0.5.1";
 
 public:
     void parse_cmdline(int argc, const char* const* argv) override


### PR DESCRIPTION
Because it's buried deep in the source file, it seems like an easy thing to miss.
Any thoughts (short of the auto-versioning we discussed previously) on making this easier?