### PR TITLE
Fixed invalid comparison in OSService::remove_file

### DIFF
--- a/sources/unix.cpp
+++ b/sources/unix.cpp
@@ -279,7 +279,7 @@ OSService::open_file_stream(StringRef path, int flags, unsigned mode) const
 
 void OSService::remove_file(StringRef path) const
 {
-    int rc = ::unlinkat(m_dir_fd, path.c_str(), 0) == 0;
+    int rc = ::unlinkat(m_dir_fd, path.c_str(), 0);
     if (rc < 0)
         THROW_POSIX_EXCEPTION(errno, "unlinking " + norm_path(path));
 }


### PR DESCRIPTION
The [remove_file](https://github.com/netheril96/securefs/blob/73f021e84cc8b6453bf9ec5d15ae4cbf2d54c785/sources/unix.cpp#L282) function cannot fail, because the statement is a boolean expression returning 1 on success or 0 on failure - `unlinkat` returns 0 on success and -1 on failure. So it's always greater than or equal to zero.

```
int rc = ::unlinkat(m_dir_fd, path.c_str(), 0) == 0;
                                               ^^^^
if (rc < 0)
    THROW_POSIX_EXCEPTION(...)
```