### PR TITLE
Fix typo in general usage information/instructions

### DIFF
--- a/sources/commands.cpp
+++ b/sources/commands.cpp
@@ -1409,7 +1409,7 @@ int commands_main(int argc, const char* const* argv)
                 }
             }
 
-            fprintf(stderr, "\nType %s ${SUBCOMMAND} --help for details\n", argv[0]);
+            fprintf(stderr, "\nType ${SUBCOMMAND} --help for details\n");
             return 1;
         };
 


### PR DESCRIPTION
I tried running `securefs --help` and got this at the end of the output:
```
Type --help ${SUBCOMMAND} --help for details
```
...It was `argv[0]` (`--help` in my case) that was being put before `${SUBCOMMAND}`. I guess it was just a typo/was left behind. I've removed it to clear up any confusion:
```
Type ${SUBCOMMAND} --help for details
```

And thank you for this great encryption filesystem!