### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/external/cryptopp/CMakeLists.txt
+++ b/external/cryptopp/CMakeLists.txt
@@ -71,7 +71,7 @@ set(TEST_CXX_FILE ${TEST_PROG_DIR}/test_cxx.cxx)
 
 option(BUILD_STATIC "Build static library" ON)
 option(BUILD_SHARED "Build shared library" OFF)
-option(BUILD_TESTING "Build library tests" OFF)
+option(BUILD_TESTING "Build library tests" ON)
 option(BUILD_DOCUMENTATION "Use Doxygen to create the HTML based API documentation" OFF)
 option(USE_INTERMEDIATE_OBJECTS_TARGET "Use a common intermediate objects target for the static and shared library targets" ON)
 


### PR DESCRIPTION
Enable tests for Crypto++ to catch compiler bugs like in https://github.com/netheril96/securefs/issues/124